### PR TITLE
support laravel 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "type": "project",
   "require": {
     "php": ">=5.5.9",
-    "illuminate/database": "~5.2"
+    "illuminate/database": "~5.2|~5.3|~5.4"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8",

--- a/src/Setting.php
+++ b/src/Setting.php
@@ -106,7 +106,7 @@ class Setting implements SettingContract
     public function find($key)
     {
         return $this->cache($key, function () use ($key) {
-            return $this->model()->whereKey($key)->first();
+            return $this->model()->where('key',$key)->first();
         });
     }
 


### PR DESCRIPTION
- starting from Laravel  v5.4 method `whereKey()` will add “where”
clause for the given primary key value